### PR TITLE
Fix some errors and Add new feature b16encode and b16decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ demo
 ```
 
 
+## Base16encode and Base16decode
+```shell
+$ python ctftool.py -16e demo
+64656D6F
+$ python ctftool.py -16d 64656D6F
+demo
+```

--- a/ctftool.py
+++ b/ctftool.py
@@ -8,6 +8,8 @@ parser.add_argument("-64e", "--base64encode", help="encode base64 string")
 parser.add_argument("-64d", "--base64decode", help="decode base64 string")
 parser.add_argument("-32e", "--base32encode", help="encode base32 string")
 parser.add_argument("-32d", "--base32decode", help="decode base32 string")
+parser.add_argument("-16e", "--base16encode", help="encode base16 string")
+parser.add_argument("-16d", "--base16decode", help="decode base16 string")
 args = parser.parse_args()
  
 
@@ -25,4 +27,12 @@ if args.base32encode:
 
 if args.base32decode:
     decode = base64.b32decode(args.base32decode)
-    print(decode)
+    print(str(decode))
+
+if args.base16encode:
+    encode = base64.b16encode(bytes(args.base16encode, encoding='utf-8'))
+    print(encode.decode("utf-8"))
+
+if args.base16decode:
+    decode = base64.b16decode(args.base16decode)
+    print(decode.decode("utf-8"))

--- a/ctftool.py
+++ b/ctftool.py
@@ -14,20 +14,20 @@ args = parser.parse_args()
  
 
 if args.base64encode:
-    encode = base64.b64encode(args.base64encode)
-    print(encode)
+    encode = base64.b64encode(bytes(args.base64encode, encoding='utf-8'))
+    print(encode.decode("utf-8"))
 
 if args.base64decode:
     decode = base64.b64decode(args.base64decode)
-    print(decode)
+    print(decode.decode("utf-8"))
 
 if args.base32encode:
-    encode = base64.b32encode(args.base32encode)
-    print(encode)
+    encode = base64.b32encode(bytes(args.base32encode, encoding='utf-8'))
+    print(encode.decode("utf-8"))
 
 if args.base32decode:
     decode = base64.b32decode(args.base32decode)
-    print(str(decode))
+    print(decode.decode("utf-8"))
 
 if args.base16encode:
     encode = base64.b16encode(bytes(args.base16encode, encoding='utf-8'))


### PR DESCRIPTION
$ python ctftool.py -16e demo
Traceback (most recent call last):
  File "ctftool.py", line 33, in <module>
    encode = base64.b16encode(args.base16encode)
  File "/usr/lib/python3.6/base64.py", line 257, in b16encode
    return binascii.hexlify(s).upper()
TypeError: a bytes-like object is required, not 'str'
